### PR TITLE
timedelta.seconds returns seconds within the day

### DIFF
--- a/report_creator.py
+++ b/report_creator.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
 			# Fill in the "latency" entry by comparing the "last" to the SOA datetime; it is stored as seconds
 			#   rsi_publication_latency[this_rsi][this_soa]["last"] might still be None for SOAs issued at the very end of the month; skip them
 			if rsi_publication_latency[this_rsi][this_soa]["last"]:
-				rsi_publication_latency[this_rsi][this_soa]["latency"] = (rsi_publication_latency[this_rsi][this_soa]["last"] - soa_first_seen[this_soa]).seconds  # [jtz]
+				rsi_publication_latency[this_rsi][this_soa]["latency"] = (rsi_publication_latency[this_rsi][this_soa]["last"] - soa_first_seen[this_soa]).total_seconds() # [jtz]
 				
 	##############################################################
 


### PR DESCRIPTION
To return the actual seconds of the duration, the total_seconds() method should be used.

```
$ python
Python 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.datetime(2024, 5, 21, 20, 15) - datetime.datetime(2024, 5, 20, 19, 35)
datetime.timedelta(days=1, seconds=2400)
>>> (datetime.datetime(2024, 5, 21, 20, 15) - datetime.datetime(2024, 5, 20, 19, 35)).seconds
2400
>>> (datetime.datetime(2024, 5, 21, 20, 15) - datetime.datetime(2024, 5, 20, 19, 35)).total_seconds()
88800.0
```