### PR TITLE
Improved RSI Publication Latency

### DIFF
--- a/report_creator.py
+++ b/report_creator.py
@@ -423,9 +423,9 @@ if __name__ == "__main__":
 		for this_soa in soa_first_seen:
 			if rsi_publication_latency[this_rsi].get(this_soa):
 				latency_differences.append(rsi_publication_latency[this_rsi][this_soa]["latency"])  # [kvg] [udz]
-		publication_latency_median = statistics.median(latency_differences)  # [yzp]
-		pass_fail_text = "Fail" if publication_latency_median > rsi_publication_latency_threshold else "Pass"
-		additional_text = f" -- {publication_latency_median:>7.1f} seconds median"
+		publication_latency_mean = statistics.mean(latency_differences)  # [yzp]
+		pass_fail_text = "Fail" if publication_latency_mean > rsi_publication_latency_threshold else "Pass"
+		additional_text = f" -- {publication_latency_mean:>7.1f} seconds mean"
 		r_out(f"    {pass_fail_text}  {len(rsi_publication_latency[this_rsi]):>8,} measurements", additional_text)  # [hms]
 
 	# RSS reports
@@ -481,10 +481,10 @@ if __name__ == "__main__":
 	# RSS publication latency
 	rss_publication_latency_threshold = 35 * 60  # [zkl]
 	r_out(f"\n\nRSS Publication Latency\nThreshold is {rss_publication_latency_threshold} seconds")  # [tkw]
-	rss_publication_latency_median = statistics.median(rss_publication_latency_list)  # [zgb]
-	pass_fail_text = "Fail" if rss_publication_latency_median > rss_publication_latency_threshold else "Pass"
+	rss_publication_latency_mean = statistics.mean(rss_publication_latency_list)  # [zgb]
+	pass_fail_text = "Fail" if rss_publication_latency_mean > rss_publication_latency_threshold else "Pass"
 	additional_text = f" -- {statistics.mean(rss_publication_latency_list):.3f} seconds mean"
-	r_out(f"   Entire RSS {rss_publication_latency_median} median, {pass_fail_text}, {len(rss_publication_latency_list):>8,} measurements", additional_text)  # [daz]
+	r_out(f"   Entire RSS {rss_publication_latency_mean} mean, {pass_fail_text}, {len(rss_publication_latency_list):>8,} measurements", additional_text)  # [daz]
 
 	##############################################################
 

--- a/report_creator.py
+++ b/report_creator.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
 			# Fill in the "latency" entry by comparing the "last" to the SOA datetime; it is stored as seconds
 			#   rsi_publication_latency[this_rsi][this_soa]["last"] might still be None for SOAs issued at the very end of the month; skip them
 			if rsi_publication_latency[this_rsi][this_soa]["last"]:
-				rsi_publication_latency[this_rsi][this_soa]["latency"] = (rsi_publication_latency[this_rsi][this_soa]["last"] - soa_first_seen[this_soa]).seconds  # [jtz]
+				rsi_publication_latency[this_rsi][this_soa]["latency"] = (rsi_publication_latency[this_rsi][this_soa]["last"] - soa_first_seen[this_soa]).total_seconds() # [jtz]
 				
 	##############################################################
 


### PR DESCRIPTION
Some improvements with respect to the "5.4. Publication latency" metric.
An extra "step" in between step 3 and 4 of the aggregation steps:

- If a new serial number is not seen because of failure to refresh, the amount of time elapsed until a given vantage point observes the first observed next new serial number is calculated. Or, if there is no first observed next new serial, the time elapsed until the current time is taken.

Also, in step 4, the median value of the aggregated latency measurement is taken, but a **median** would not detect incidental but long stretches of missed updates. The mean is more suitable for this. The failures of C-root to refresh in May are detected using the mean with the currently defined thresholds for the metric.
