### PR TITLE
Recent dnspython >= 2.6.0 has NSIDOption

### DIFF
--- a/Tests/make_tests.py
+++ b/Tests/make_tests.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 		r_dict["flags"] = dns.flags.to_text(r.flags)
 		r_dict["edns"] = {}
 		for this_option in r.options:
-			r_dict["edns"][this_option.otype.value] = this_option.data.decode("ascii")
+			r_dict["edns"][this_option.otype.value] = this_option.to_text()
 		get_sections = ("question", "answer", "authority", "additional")
 		for (this_section_number, this_section_name) in enumerate(get_sections):
 			r_dict[this_section_name] = []

--- a/vantage_point_metrics.py
+++ b/vantage_point_metrics.py
@@ -93,7 +93,7 @@ def do_one_query(target, internet, ip_addr, transport, query, test_type):
 		r_dict["flags"] = dns.flags.to_text(r.flags)
 		r_dict["edns"] = {}
 		for this_option in r.options:
-			r_dict["edns"][this_option.otype.value] = this_option.data
+			r_dict["edns"][this_option.otype.value] = this_option.to_text()
 		if test_type == "C":
 			get_sections = ("question", "answer", "authority", "additional")
 		else:


### PR DESCRIPTION
Since version 2.6.0 dnspython has support for the NSID option (see: https://dnspython.readthedocs.io/en/latest/whatsnew.html ). As a result a returned NSID option in a response object is no longer a GenericOption and no longer has the `.data` member. Only GenericOption has the `.data` member. We can fix by using the more generic `to_text()` method instead which is also used with other dnspython objects elsewhere within the code base.