### PR TITLE
Make deployment work on latest Debian (bookwork)

### DIFF
--- a/Ansible/collector_building.yml
+++ b/Ansible/collector_building.yml
@@ -1,6 +1,8 @@
 - name: Set up the machine as root
   hosts: c07
   remote_user: "{{ superuser }}"
+  become_user: root
+  become: yes
   tasks:
   - name: Initialize apt
     apt:
@@ -12,7 +14,7 @@
   - name: Install all the needed packages
     apt:
       pkg: [acl, build-essential, curl, git, libcap-dev, libgetdns-dev, libidn11-dev, libldns-dev, libssl-dev, libtool, libtool-bin, libunbound-dev, libuv1-dev,
-        man, pkg-config, postgresql, pyflakes3, python-ply, python3-psycopg2, python3-paramiko, python3-pip, rsync, unzip]
+        man, pkg-config, postgresql, pyflakes3, python3-psycopg2, python3-paramiko, python3-pip, rsync, unzip]
   - name: Put .bashrc for root
     copy:
       src: ../bashrc-for-metrics-and-root
@@ -104,8 +106,8 @@
       version: main     # no-transfer-user
   - name: get dnspython
     shell:
-      cmd: "pip3 install --user dnspython"
-      creates: /home/metrics/.local/lib/python3.7/site-packages/dns
+      cmd: "pip3 install --user dnspython || pip3 install --break-system-packages --user dnspython"
+      creates: /home/metrics/.local/lib/python3.9/site-packages/dns
   - name: crontab entry for get_root_zone.py
     cron:   # [mba] [wca]
       disabled: yes

--- a/Ansible/vps_building.yml
+++ b/Ansible/vps_building.yml
@@ -13,7 +13,7 @@
       force: true
   - name: Install all the needed packages
     apt:
-      pkg: [build-essential, curl, git, libbind-dev, libldns-dev, libpcap-dev, libssl-dev, libyaml-perl, man, pkg-config,
+      pkg: [build-essential, curl, git, libldns-dev, libpcap-dev, libssl-dev, libyaml-perl, man, pkg-config,
         pyflakes3, python3-pip, python3-requests, rsync, scamper, sudo, traceroute, unzip, zlib1g-dev]
   - name: Put .bashrc for root
     copy:
@@ -106,7 +106,7 @@
       creates: /home/metrics/Target/bin/dnscap
   - name: Get dnspython
     shell:
-      cmd: "pip3 install --user dnspython"
+      cmd: "pip3 install --user dnspython || pip3 install --break-system-packages --user dnspython"
       creates: /home/metrics/.local/lib/python3.7/site-packages/dns
   - name: Pull or freshen the Github repo
     git:


### PR DESCRIPTION
The README says the deployment should work on the latest Debian. They worked fine on Debian 11 (bullseye), but a few changes needed to be made to make it work on Debian 12 (bookworm). This includes removal of some package installations (that weren't necessary anyway), and allowing pip3 to "break system packages". Also more privileges were needed to deploy the collector.